### PR TITLE
Implement 'local' Command for Enhanced AFT Local Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ aft-deployment.zip
 
 *.cast
 dist/
+
+example-local.sh

--- a/cmd/aft/deploy/cmd.go
+++ b/cmd/aft/deploy/cmd.go
@@ -256,7 +256,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, _ []string) {
-	awsClient := aws.NewClient()
+	awsClient := aws.NewClient("")
 
 	interpolatedCodeSuiteBucketName := args.aftManagementAccountID + "-" + args.codePipelineBucketName
 	interpolatedTerraformBucketName := args.aftManagementAccountID + "-" + args.terraformStateBucketName

--- a/cmd/aftctl/aftctl.go
+++ b/cmd/aftctl/aftctl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/edgarsilva948/aftctl/cmd/aft"
 	"github.com/edgarsilva948/aftctl/cmd/completion"
 	"github.com/edgarsilva948/aftctl/cmd/docs"
+	"github.com/edgarsilva948/aftctl/cmd/local"
 	"github.com/edgarsilva948/aftctl/cmd/version"
 
 	"github.com/edgarsilva948/aftctl/pkg/color"
@@ -36,6 +37,7 @@ func init() {
 	root.AddCommand(docs.Cmd)
 	root.AddCommand(version.Cmd)
 	root.AddCommand(aft.Cmd)
+	root.AddCommand(local.Cmd)
 }
 
 func main() {

--- a/cmd/local/cmd.go
+++ b/cmd/local/cmd.go
@@ -5,11 +5,42 @@ Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
 package local
 
 import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"log"
 	"os"
 
+	"path/filepath"
+	"strings"
+
+	"github.com/edgarsilva948/aftctl/pkg/aws"
+	profile "github.com/edgarsilva948/aftctl/pkg/aws/profiles"
+	"github.com/edgarsilva948/aftctl/pkg/logging"
 	validate "github.com/edgarsilva948/aftctl/pkg/validator"
+	"github.com/flosch/pongo2"
+
 	"github.com/spf13/cobra"
 )
+
+const (
+	aftMgmtAccountID     = "/aft/account/aft-management/account-id"
+	tfDistribution       = "/aft/config/terraform/distribution"
+	ctMgmtRegion         = "/aft/config/ct-management-region"
+	aftAdminRoleName     = "/aft/resources/iam/aft-administrator-role-name"
+	aftExecutionRoleName = "/aft/resources/iam/aft-execution-role-name"
+	aftSessionName       = "/aft/resources/iam/aft-session-name"
+	tfBackendRegion      = "/aft/config/oss-backend/primary-region"
+	tfKmsKeyID           = "/aft/config/oss-backend/kms-key-id"
+	tfDynamoDBTableName  = "/aft/config/oss-backend/table-id"
+	tfS3BucketID         = "/aft/config/oss-backend/bucket-id"
+	tfVarFile            = "aft-input.auto.tfvars"
+)
+
+const assumeRoleIcon = "🔄"
+const profileIcon = "📝"
 
 var args struct {
 	targetAccount    string
@@ -40,21 +71,191 @@ func init() {
 // Cmd represents the Cobra command for the local AFT execution.
 var Cmd = &cobra.Command{
 	Use:   "local",
-	Short: "Runs local AFT execution",
+	Short: "Runs AFT locally",
 	Long:  "Runs AFT locally executing the same commands as the pipeline",
 	Run:   Run,
 }
 
 // Run executes the local command
 func Run(cmd *cobra.Command, argv []string) {
+	// defining the S3 key for the local execution
+	var tfS3Key string
+
+	// validate input account ID
 	_, err := validate.CheckAWSAccountID(args.targetAccount)
 	if err != nil {
 		os.Exit(1)
 	}
 
+	// validate input terraform command
 	_, err = validate.CheckTerraformCommand(args.terraformCommand)
 	if err != nil {
 		os.Exit(1)
 	}
+
+	// client initialization with AFT Credentials
+	message := "Initializing AWS Client using AFT Account credentials... step (1/3)"
+	logging.CustomLog(profileIcon, "green", message)
+
+	awsClient := aws.NewClient("")
+
+	aftMgmtAccountIDParam, err := aws.GetSSMParameter(awsClient.GetSSMClient(), aftMgmtAccountID)
+	if err != nil {
+		log.Fatalf("Failed to get SSM Parameter: %v", err)
+		os.Exit(1)
+	}
+
+	tfDistributionParam, err := aws.GetSSMParameter(awsClient.GetSSMClient(), tfDistribution)
+	if err != nil {
+		log.Fatalf("Failed to get SSM Parameter: %v", err)
+		os.Exit(1)
+	}
+
+	ctMgmtRegionParam, err := aws.GetSSMParameter(awsClient.GetSSMClient(), ctMgmtRegion)
+	if err != nil {
+		log.Fatalf("Failed to get SSM Parameter: %v", err)
+		os.Exit(1)
+	}
+
+	aftAdminRoleNameParam, err := aws.GetSSMParameter(awsClient.GetSSMClient(), aftAdminRoleName)
+	if err != nil {
+		log.Fatalf("Failed to get SSM Parameter: %v", err)
+		os.Exit(1)
+	}
+	aftExecutionRoleNameParam, err := aws.GetSSMParameter(awsClient.GetSSMClient(), aftExecutionRoleName)
+	if err != nil {
+		log.Fatalf("Failed to get SSM Parameter: %v", err)
+		os.Exit(1)
+	}
+
+	tfBackendRegionParam, err := aws.GetSSMParameter(awsClient.GetSSMClient(), tfBackendRegion)
+	if err != nil {
+		log.Fatalf("Failed to get SSM Parameter: %v", err)
+		os.Exit(1)
+	}
+
+	tfKmsKeyIDParam, err := aws.GetSSMParameter(awsClient.GetSSMClient(), tfKmsKeyID)
+	if err != nil {
+		log.Fatalf("Failed to get SSM Parameter: %v", err)
+		os.Exit(1)
+	}
+
+	tfDynamoDBTableNameParam, err := aws.GetSSMParameter(awsClient.GetSSMClient(), tfDynamoDBTableName)
+	if err != nil {
+		log.Fatalf("Failed to get SSM Parameter: %v", err)
+		os.Exit(1)
+	}
+
+	tfS3BucketIDParam, err := aws.GetSSMParameter(awsClient.GetSSMClient(), tfS3BucketID)
+	if err != nil {
+		log.Fatalf("Failed to get SSM Parameter: %v", err)
+		os.Exit(1)
+	}
+
+	// check if the current directory is aft-account-customizations or aft-global-customizations
+	pwd, err := os.Getwd()
+	if err != nil {
+		fmt.Println("Error getting current directory:", err)
+		return
+	}
+
+	// check if the current directory is aft-account-customizations or aft-global-customizations and defining the S3 key for the local execution
+	if strings.Contains(pwd, "aft-account-customizations") {
+		tfS3Key = fmt.Sprintf("%s-aft-account-customizations/terraform.tfstate", args.targetAccount)
+	} else if strings.Contains(pwd, "aft-global-customizations") {
+		tfS3Key = fmt.Sprintf("%s-aft-global-customizations/terraform.tfstate", args.targetAccount)
+	} else {
+		fmt.Println("Run aftctl local from the aft-account-customizations or aft-global-customizations repository.")
+		return
+	}
+
+	// setting up the AWS profile for the AFT Account using the user current credentials
+	if err := profile.SetupProfile(awsClient.GetSTSClient(), aftMgmtAccountIDParam, aftAdminRoleNameParam, "AWSAFT-Session"); err != nil {
+		fmt.Println("Error setting up profile", err)
+	}
+
+	message = fmt.Sprintf("Successfully set up AWS profile %s-%s Step (2/3)", aftMgmtAccountIDParam, aftAdminRoleNameParam)
+	logging.CustomLog(assumeRoleIcon, "green", message)
+
+	// Assuming the AFT Admin Role in the AFT Account
+	profileVariable := aftMgmtAccountIDParam + "-" + aftAdminRoleNameParam
+	aws.NewClient(profileVariable)
+	accessKey, secretKey, sessionToken, err := aws.GetAWSCredentials(profileVariable)
+	if err != nil {
+		fmt.Println("error getting AFT Admin credentials")
+	}
+
+	// Set the AWS_PROFILE environment variable
+	err = os.Setenv("AWS_PROFILE", profileVariable)
+	if err != nil {
+		log.Fatalf("Error setting env var AWS_PROFILE: %v", err)
+	}
+
+	files, err := filepath.Glob("*.jinja")
+	if err != nil {
+		fmt.Println("Error reading jinja files:", err)
+		return
+	}
+
+	for _, f := range files {
+		input, err := os.ReadFile(f)
+		if err != nil {
+			fmt.Println("Error reading file:", f, err)
+			continue
+		}
+
+		template, err := pongo2.FromString(string(input))
+		if err != nil {
+			fmt.Println("Error parsing template:", err)
+			continue
+		}
+
+		partition := "aws"
+		timestamp := time.Now().Format(time.RFC3339)
+
+		output, err := template.Execute(pongo2.Context{
+			"timestamp":             timestamp,
+			"tf_distribution_type":  tfDistributionParam,
+			"provider_region":       ctMgmtRegionParam,
+			"region":                tfBackendRegionParam,
+			"aft_admin_role_arn":    fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, aftMgmtAccountIDParam, aftExecutionRoleNameParam),
+			"target_admin_role_arn": fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, args.targetAccount, aftExecutionRoleNameParam),
+			"bucket":                tfS3BucketIDParam,
+			"key":                   tfS3Key,
+			"dynamodb_table":        tfDynamoDBTableNameParam,
+			"kms_key_id":            tfKmsKeyIDParam,
+		})
+		if err != nil {
+			fmt.Println("Error executing template:", err)
+			continue
+		}
+
+		outputFile := fmt.Sprintf("./%s.tf", strings.TrimSuffix(f, ".jinja"))
+		if err := os.WriteFile(outputFile, []byte(output), 0644); err != nil {
+			fmt.Println("Error writing output file:", err)
+			continue
+		}
+	}
+
+	message = fmt.Sprintf("Executing Terraform command %s... (3/3)", args.terraformCommand)
+	logging.CustomLog(profileIcon, "green", message)
+
+	terraformCmd := exec.Command("terraform", args.terraformCommand)
+	terraformCmd.Env = append(os.Environ(),
+		"AWS_ACCESS_KEY_ID="+accessKey,
+		"AWS_SECRET_ACCESS_KEY="+secretKey,
+		"AWS_SESSION_TOKEN="+sessionToken,
+	)
+
+	var stdout, stderr bytes.Buffer
+	terraformCmd.Stdout = &stdout
+	terraformCmd.Stderr = &stderr
+
+	err = terraformCmd.Run()
+	if err != nil {
+		log.Fatalf("cmd.Run() failed: %s\nStderr: %s", err, stderr.String())
+	}
+
+	fmt.Printf("Output:\n%s\n", stdout.String())
 
 }

--- a/cmd/local/cmd.go
+++ b/cmd/local/cmd.go
@@ -2,6 +2,7 @@
 Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
 */
 
+// Package local provides the local command
 package local
 
 import (
@@ -18,6 +19,7 @@ import (
 
 	"github.com/edgarsilva948/aftctl/pkg/aws"
 	profile "github.com/edgarsilva948/aftctl/pkg/aws/profiles"
+	"github.com/edgarsilva948/aftctl/pkg/gitignore"
 	"github.com/edgarsilva948/aftctl/pkg/logging"
 	validate "github.com/edgarsilva948/aftctl/pkg/validator"
 	"github.com/flosch/pongo2"
@@ -41,6 +43,8 @@ const (
 
 const assumeRoleIcon = "🔄"
 const profileIcon = "📝"
+const gitIgnoreIcon = "⚙️"
+const terraformIcon = "⛏️ "
 
 var args struct {
 	targetAccount    string
@@ -94,7 +98,7 @@ func Run(cmd *cobra.Command, argv []string) {
 	}
 
 	// client initialization with AFT Credentials
-	message := "Initializing AWS Client using AFT Account credentials... step (1/3)"
+	message := "Initializing AWS Client using AFT Account credentials... step (1/4)"
 	logging.CustomLog(profileIcon, "green", message)
 
 	awsClient := aws.NewClient("")
@@ -174,7 +178,7 @@ func Run(cmd *cobra.Command, argv []string) {
 		fmt.Println("Error setting up profile", err)
 	}
 
-	message = fmt.Sprintf("Successfully set up AWS profile %s-%s Step (2/3)", aftMgmtAccountIDParam, aftAdminRoleNameParam)
+	message = fmt.Sprintf("Successfully set up AWS profile %s-%s Step (2/4)", aftMgmtAccountIDParam, aftAdminRoleNameParam)
 	logging.CustomLog(assumeRoleIcon, "green", message)
 
 	// Assuming the AFT Admin Role in the AFT Account
@@ -237,8 +241,19 @@ func Run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	message = fmt.Sprintf("Executing Terraform command %s... (3/3)", args.terraformCommand)
-	logging.CustomLog(profileIcon, "green", message)
+	gitIgnoreGenerated := gitignore.GenerateGitIgnore()
+
+	if !gitIgnoreGenerated {
+		log.Fatalf("error generating .gitignore file")
+	}
+
+	if gitIgnoreGenerated {
+		message = ".gitignore successfully generated... (3/4)"
+		logging.CustomLog(gitIgnoreIcon, "green", message)
+	}
+
+	message = fmt.Sprintf("Executing Terraform command %s... (4/4)", args.terraformCommand)
+	logging.CustomLog(terraformIcon, "green", message)
 
 	terraformCmd := exec.Command("terraform", args.terraformCommand)
 	terraformCmd.Env = append(os.Environ(),

--- a/cmd/local/cmd.go
+++ b/cmd/local/cmd.go
@@ -1,0 +1,60 @@
+/*
+Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
+*/
+
+package local
+
+import (
+	"os"
+
+	validate "github.com/edgarsilva948/aftctl/pkg/validator"
+	"github.com/spf13/cobra"
+)
+
+var args struct {
+	targetAccount    string
+	terraformCommand string
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.SortFlags = false
+
+	flags.StringVarP(
+		&args.targetAccount,
+		"target-account",
+		"a",
+		"",
+		"Account ID to be targeted during local execution",
+	)
+
+	flags.StringVarP(
+		&args.terraformCommand,
+		"terraform-command",
+		"c",
+		"",
+		"The terraform command to be executed locally",
+	)
+}
+
+// Cmd represents the Cobra command for the local AFT execution.
+var Cmd = &cobra.Command{
+	Use:   "local",
+	Short: "Runs local AFT execution",
+	Long:  "Runs AFT locally executing the same commands as the pipeline",
+	Run:   Run,
+}
+
+// Run executes the local command
+func Run(cmd *cobra.Command, argv []string) {
+	_, err := validate.CheckAWSAccountID(args.targetAccount)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	_, err = validate.CheckTerraformCommand(args.terraformCommand)
+	if err != nil {
+		os.Exit(1)
+	}
+
+}

--- a/cmd/local/test_cmd.go
+++ b/cmd/local/test_cmd.go
@@ -1,0 +1,173 @@
+/*
+Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
+*/
+
+// Package local provides the local command
+package local
+
+import (
+	"errors"
+	"os"
+
+	awsAft "github.com/edgarsilva948/aftctl/pkg/aws"
+	profile "github.com/edgarsilva948/aftctl/pkg/aws/profiles"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+
+	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+// MockSTSClient is a mock implementation of an STS client for testing.
+type MockSTSClient struct {
+	stsiface.STSAPI
+	AssumeRoleFunc func(*sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
+}
+
+// MockSSMClient is a mock implementation of an SSM client for testing.
+type MockSSMClient struct {
+	ssmiface.SSMAPI
+	GetParameterFunc func(*ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+}
+
+// GetParameter is a mock implementation of the GetParameter method.
+func (m *MockSSMClient) GetParameter(input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+	return m.GetParameterFunc(input)
+}
+
+// AssumeRole is a mock implementation of the AssumeRole method.
+func (m *MockSTSClient) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+	return m.AssumeRoleFunc(input)
+}
+
+var _ = ginkgo.Describe("Interacting with the SSM API", func() {
+	var (
+		originalWd string
+		err        error
+	)
+
+	// Use BeforeEach and AfterEach for setup and teardown specific to this Describe block
+	ginkgo.BeforeEach(func() {
+		originalWd, err = os.Getwd()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.AfterEach(func() {
+		err := os.Chdir(originalWd)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.Context("testing the GetSSMParameter function", func() {
+
+		var mockClient *MockSSMClient
+
+		ginkgo.BeforeEach(func() {
+			mockClient = &MockSSMClient{}
+		})
+
+		ginkgo.When("parameter retrieval is successful", func() {
+			ginkgo.It("should return the parameter value", func() {
+				mockClient.GetParameterFunc = func(*ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+					return &ssm.GetParameterOutput{
+						Parameter: &ssm.Parameter{
+							Value: aws.String("some_value"),
+						},
+					}, nil
+				}
+
+				value, err := awsAft.GetSSMParameter(mockClient, "some_parameter")
+				gomega.Expect(err).To(gomega.BeNil())
+				gomega.Expect(value).To(gomega.Equal("some_value"))
+			})
+		})
+
+		ginkgo.When("parameter retrieval fails", func() {
+			ginkgo.It("should return an error", func() {
+				mockClient.GetParameterFunc = func(*ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+					return nil, errors.New("some error")
+				}
+				value, err := awsAft.GetSSMParameter(mockClient, "some_parameter")
+				gomega.Expect(err).ToNot(gomega.BeNil())
+				gomega.Expect(err.Error()).To(gomega.Equal("some error"))
+				gomega.Expect(value).To(gomega.BeEmpty())
+			})
+		})
+
+	})
+
+	ginkgo.Context("when getting the current directory", func() {
+		ginkgo.When("there is no error", func() {
+			ginkgo.It("should return the current directory", func() {
+				pwd, err := os.Getwd()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(pwd).To(gomega.Equal(originalWd))
+			})
+		})
+
+		ginkgo.When("there is an error", func() {
+			ginkgo.It("should handle the error", func() {
+
+				err := os.Chdir("/non/existent/directory")
+				gomega.Expect(err).To(gomega.HaveOccurred())
+
+				_, err = os.Getwd()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+		})
+
+	})
+
+	ginkgo.Context("when setting up the profile", func() {
+		var mockSTSClient *MockSTSClient
+		var aftMgmtAccountIDParam string
+		var aftAdminRoleNameParam string
+
+		ginkgo.BeforeEach(func() {
+			mockSTSClient = &MockSTSClient{
+				AssumeRoleFunc: func(*sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+					return &sts.AssumeRoleOutput{}, nil
+				},
+			}
+			aftMgmtAccountIDParam = "someAccountID"
+			aftAdminRoleNameParam = "someRoleName"
+		})
+
+		ginkgo.When("there is no error", func() {
+			ginkgo.It("should complete without error", func() {
+
+				mockSTSClient = &MockSTSClient{
+					AssumeRoleFunc: func(*sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+						return &sts.AssumeRoleOutput{
+							Credentials: &sts.Credentials{
+								AccessKeyId:     aws.String("some-access-key-id"),
+								SecretAccessKey: aws.String("some-secret-access-key"),
+								SessionToken:    aws.String("some-session-token"),
+							},
+						}, nil
+					},
+				}
+				err := profile.SetupProfile(mockSTSClient, aftMgmtAccountIDParam, aftAdminRoleNameParam, "AWSAFT-Session")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.When("there is an error", func() {
+			ginkgo.BeforeEach(func() {
+				mockSTSClient.AssumeRoleFunc = func(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+					return nil, errors.New("some error")
+				}
+			})
+
+			ginkgo.It("should handle the error", func() {
+				err := profile.SetupProfile(mockSTSClient, aftMgmtAccountIDParam, aftAdminRoleNameParam, "AWSAFT-Session")
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).To(gomega.Equal("some error"))
+			})
+		})
+	})
+
+})

--- a/cmd/local/version_suite_test.go
+++ b/cmd/local/version_suite_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
+*/
+
+package local_test
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Local Suite")
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 // indirect
+	github.com/flosch/pongo2/v6 v6.0.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
@@ -25,6 +27,7 @@ require (
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/tools v0.12.0 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,10 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 h1:fmFk0Wt3bBxxwZnu48jqMdaOR/IZ4vdtJFuaFV8MpIE=
+github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3/go.mod h1:bJWSKrZyQvfTnb2OudyUjurSG4/edverV7n82+K3JiM=
+github.com/flosch/pongo2/v6 v6.0.0 h1:lsGru8IAzHgIAw6H2m4PCyleO58I40ow6apih0WprMU=
+github.com/flosch/pongo2/v6 v6.0.0/go.mod h1:CuDpFm47R0uGGE7z13/tTlt1Y6zdxvr2RLT5LJhsHEU=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
@@ -23,6 +27,9 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo/v2 v2.12.0 h1:UIVDowFPwpg6yMUpPjGkYvf06K3RAiJXUhCxEwQVHRI=
 github.com/onsi/ginkgo/v2 v2.12.0/go.mod h1:ZNEzXISYlqpb8S36iN71ifqLi3vVD1rVJGvWRCJOUpQ=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
@@ -87,6 +94,10 @@ google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscL
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/pkg/aws/profiles/profile.go
+++ b/pkg/aws/profiles/profile.go
@@ -6,6 +6,7 @@ Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
 package profile
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -18,6 +19,10 @@ import (
 // SetupProfile creates a new profile for AWS CLI (~/.aws/credentials)
 func SetupProfile(client awsClient.STSClient, accountID string, roleName string, roleSession string) error {
 
+	if client == nil {
+		return errors.New("client is nil")
+	}
+
 	input := &sts.AssumeRoleInput{
 		RoleArn:         aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, roleName)),
 		RoleSessionName: aws.String(roleSession),
@@ -26,6 +31,10 @@ func SetupProfile(client awsClient.STSClient, accountID string, roleName string,
 	result, err := client.AssumeRole(input)
 	if err != nil {
 		return err
+	}
+
+	if result == nil || result.Credentials == nil {
+		return errors.New("result or result.Credentials is nil")
 	}
 
 	// Construct profile name

--- a/pkg/aws/profiles/profile.go
+++ b/pkg/aws/profiles/profile.go
@@ -1,0 +1,69 @@
+/*
+Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
+*/
+
+// Package profile implements a new profile for AWS CLI
+package profile
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+	awsClient "github.com/edgarsilva948/aftctl/pkg/aws"
+	"gopkg.in/ini.v1"
+)
+
+// SetupProfile creates a new profile for AWS CLI (~/.aws/credentials)
+func SetupProfile(client awsClient.STSClient, accountID string, roleName string, roleSession string) error {
+
+	input := &sts.AssumeRoleInput{
+		RoleArn:         aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, roleName)),
+		RoleSessionName: aws.String(roleSession),
+	}
+
+	result, err := client.AssumeRole(input)
+	if err != nil {
+		return err
+	}
+
+	// Construct profile name
+	profileName := fmt.Sprintf("%s-%s", accountID, roleName)
+
+	// Get the AWS config file path
+	awsConfigFile := fmt.Sprintf("%s/.aws/credentials", os.Getenv("HOME"))
+
+	// Check if the file exists, if not, create it
+	if _, err := os.Stat(awsConfigFile); os.IsNotExist(err) {
+		// Create the directory if not exists
+		if err := os.MkdirAll(fmt.Sprintf("%s/.aws", os.Getenv("HOME")), 0755); err != nil {
+			return err
+		}
+
+		// Create the file
+		_, err := os.Create(awsConfigFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Load the AWS config file
+	cfg, err := ini.Load(awsConfigFile)
+	if err != nil {
+		return err
+	}
+
+	// Create a new section (AWS profile) or update an existing one
+	sec, err := cfg.NewSection(profileName)
+	if err != nil {
+		return err
+	}
+
+	sec.Key("aws_access_key_id").SetValue(*result.Credentials.AccessKeyId)
+	sec.Key("aws_secret_access_key").SetValue(*result.Credentials.SecretAccessKey)
+	sec.Key("aws_session_token").SetValue(*result.Credentials.SessionToken)
+
+	// Save the updated AWS config file
+	return cfg.SaveTo(awsConfigFile)
+}

--- a/pkg/aws/ssm.go
+++ b/pkg/aws/ssm.go
@@ -1,0 +1,27 @@
+/*
+Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
+*/
+
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+// GetSSMParameter from AFT Account
+func GetSSMParameter(client SSMClient, paramName string) (string, error) {
+
+	input := &ssm.GetParameterInput{
+		Name:           aws.String(paramName),
+		WithDecryption: aws.Bool(true),
+	}
+
+	result, err := client.GetParameter(input)
+
+	if err != nil {
+		return "", err
+	}
+
+	return *result.Parameter.Value, nil
+}

--- a/pkg/gitignore/generator.go
+++ b/pkg/gitignore/generator.go
@@ -1,0 +1,35 @@
+/*
+Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
+*/
+
+// Package gitignore generates a .gitignore file
+package gitignore
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// GenerateGitIgnore generates a .gitignore file
+func GenerateGitIgnore() bool {
+	ignoreList := []string{
+		"aft-input.auto.tfvars",
+		"aft-providers.tf",
+		"backend.tf",
+		"locals.tf",
+	}
+
+	// Join the list into a single string with newlines
+	content := strings.Join(ignoreList, "\n")
+
+	// Write the content to .gitignore
+	err := os.WriteFile(".gitignore", []byte(content), 0644)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return false
+	}
+
+	return true
+
+}

--- a/pkg/validator/validate.go
+++ b/pkg/validator/validate.go
@@ -39,13 +39,12 @@ func CheckTerraformCommand(command string) (bool, error) {
 	// Check if command is accepted
 	for _, acceptedCommand := range acceptedCommands {
 		if command == acceptedCommand {
-			fmt.Println("command accepted")
 			return true, nil
-		} else {
-			fmt.Printf("command is invalid: accepted commands are %s\n", acceptedCommands)
-			return false, err
 		}
+
 	}
 
-	return true, nil
+	fmt.Printf("command is invalid: accepted commands are %s\n", acceptedCommands)
+	return false, err
+
 }

--- a/pkg/validator/validate.go
+++ b/pkg/validator/validate.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2023 Edgar Costa edgarsilva948@gmail.com
+*/
+
+package validate
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// CheckAWSAccountID checks if a string represents a valid AWS account id
+func CheckAWSAccountID(accountID string) (bool, error) {
+	var err error
+	if len(accountID) != 12 {
+		fmt.Printf("error: account id must be 12 characters long\n")
+		return false, err
+	}
+
+	// Check if all characters are digits
+	_, err = strconv.ParseUint(accountID, 10, 64)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// CheckTerraformCommand checks if a string represents a valid AWS account id
+func CheckTerraformCommand(command string) (bool, error) {
+	var err error
+
+	acceptedCommands := []string{"plan", "apply", "destroy", "init"}
+
+	if command == "" {
+		fmt.Printf("error: terraform command is required\n")
+	}
+
+	// Check if command is accepted
+	for _, acceptedCommand := range acceptedCommands {
+		if command == acceptedCommand {
+			fmt.Println("command accepted")
+			return true, nil
+		} else {
+			fmt.Printf("command is invalid: accepted commands are %s\n", acceptedCommands)
+			return false, err
+		}
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
This PR introduces the local command, which simplifies the local development process for AFT. Using this new command you can run locally:

- terraform init
- terraform plan
- terraform apply

It facilitates the testing process because you can avoid the time spent during pipelines creation, requirements installation and others.

List of Features:

Command: aftctl local

Options:
- -a/--target-account = Account ID to be targeted during local execution
- -c/--terraform-command = The terraform command to be executed locally

- Integration with the SSM API to fetch and store secure parameters
- Integration with the STS API to assume the AFT Role
- generating .gitignore files to avoid pushing not intended files
- converting some local AFT files like jinja to .tf

this is the MVP for this issue: #6 